### PR TITLE
set custom epiphany homepage-url for graphical session

### DIFF
--- a/initramfs-tools/lib/live/boot/9990-chimera-graphical.sh
+++ b/initramfs-tools/lib/live/boot/9990-chimera-graphical.sh
@@ -25,6 +25,11 @@ sleep-inactive-ac-type='nothing'
 sleep-inactive-battery-type='nothing'
 power-button-action='interactive'
 EOF
+        # set appropriate homepage for GNOME Web
+        cat << EOF > /root/etc/dconf/db/local.d/02-epiphany-homepage
+[org/gnome/epiphany]
+homepage-url='https://chimera-linux.org'
+EOF
         # refresh
         chroot /root dconf update
     fi


### PR DESCRIPTION
People will likely want to visit https://chimera-linux.org when setting up a system and look at the docs page etc when booted into GNOME on the live session.