### PR TITLE
mklive, mkrootfs: run apk with --no-interactive

### DIFF
--- a/mklive.sh
+++ b/mklive.sh
@@ -56,7 +56,7 @@ fi
 APK_ARCH=$(${APK_BIN} --print-arch)
 
 run_apk() {
-    "$APK_BIN" ${APK_REPO} --arch ${APK_ARCH} --root "$@"
+    "$APK_BIN" ${APK_REPO} --arch ${APK_ARCH} --root "$@" --no-interactive
 }
 
 while getopts "a:f:k:o:p:r:h" opt; do

--- a/mkrootfs.sh
+++ b/mkrootfs.sh
@@ -52,7 +52,7 @@ fi
 APK_ARCH=$(${APK_BIN} --print-arch)
 
 run_apk() {
-    "$APK_BIN" ${APK_REPO} --arch ${APK_ARCH} --root "$@"
+    "$APK_BIN" ${APK_REPO} --arch ${APK_ARCH} --root "$@" --no-interactive
 }
 
 while getopts "a:b:B:f:k:o:p:r:h" opt; do


### PR DESCRIPTION
Otherwise host having `/etc/apk/interactive` will make the script interactive for `apk` actions like installing packages for new image.