### PR TITLE
mkrootfs-platform: don't include firmware in -full rootfs images

### DIFF
--- a/mkrootfs-platform.sh
+++ b/mkrootfs-platform.sh
@@ -32,7 +32,7 @@ for pkg in ${PLATFORMS}; do
     if [ "$pkg" = "$PLATFORM" ]; then
         case "$PLATFORM" in
             bootstrap) BASE_PKG="base-bootstrap" ;;
-            full) ;;
+            full) KERNEL_PKG="!base-full-firmware" ;;
             rpi) KERNEL_PKG="linux-rpi" ;;
             *) KERNEL_PKG="linux-lts" ;;
         esac


### PR DESCRIPTION
Since there is no kernel (linux) in rootfs images, there is no
point to carry the chunky firmware around. For x86_64, it weighs
376 MiB uncompressed and 349 MiB compressed. Removing firmware
reduces the resulting image size to 258 MiB (uncompressed) and
97 MiB (compressed). (!)
