### PR TITLE
Fix legacy BIOS boot on stricter BIOSes requiring an active MBR/DOS partition

### DIFF
--- a/mklive.sh
+++ b/mklive.sh
@@ -315,6 +315,7 @@ chroot "${ROOT_DIR}" /usr/bin/grub-mkrescue -o - \
     --product-name "Chimera Linux" \
     --product-version "${ISO_VERSION}" \
     /mnt \
+    --mbr-force-bootable \
     -volid "CHIMERA_LIVE" > "${OUT_FILE}" || die "failed to generate ISO image"
 
 umount -f "${ROOT_DIR}/mnt"


### PR DESCRIPTION
**Short version**: This MR fixes booting Chimera ISO images written to a USB device on older BIOS machines which require a bootable MBR/DOS style partition to exist on the USB device before showing it as a bootable device.

**Long version**: I was trying to install Chimera Linux on my corebooted t440p, and an older Sony VAIO laptop, and couldn't get the install media to recognize as a bootable device when written to a USB drive.

After experimenting for a little bit I noticed that the main difference between MBR/BIOS boot images which worked on these machines and those which didn't (like the Chimera Linux ISO images written to a USB device) was that the working ones used MBR/DOS partition tables with an "active" or "boot" flagged partition pointing a the boot partition (partition flag 0x80).

Tools like `isolinux` from the `syslinux` suite add this automatically, so these typically work well on older machines. Chimera live images use `grub2-mkrescue` (which is great, and super flexible, and compiles nicely under Chimera's toolchain). But the resulting images do not have a bootable MBR/DOS partition so they are not bootable on these types of BIOS-boot machines.

However, `xorriso` does have a flag (`--mbr-force-bootable`) for adding a compatible bootable partition to the protective/fake MBR DOS partition table embedded in the GPT partition table generated for hybrid boot images (BIOS+UEFI+CD). This flag produces images which are bootable by BIOS machines which previously did not boot the image, such as SeaBIOS and other machines I tested.

So, this MR enables a "fake" bootable partition in the protective MBR which is embedded in the GPT filesystem created by `xorriso`/`grub-mkrescue`. This allows stricter legacy BIOS implementations to detect the Chimera boot images as bootable when written to USB, and subsequently allows them to be booted and Chimera Linux installed on these machines.