### PR TITLE
Snapdragon X Series SoC devicetree-based support for aarch64

### DIFF
--- a/mklive.sh
+++ b/mklive.sh
@@ -119,6 +119,8 @@ case "$MKLIVE_BOOTLOADER" in
         esac
 esac
 
+[ "$APK_ARCH" = "aarch64" ] && HOST_PACKAGES="$HOST_PACKAGES dtc"
+
 shift $((OPTIND - 1))
 
 ISO_VERSION=$(date '+%Y%m%d')
@@ -435,6 +437,30 @@ generate_menu grub/menu.cfg.in > "${IMAGE_DIR}/boot/grub/grub.cfg"
 case "$MKLIVE_BOOTLOADER" in
     limine)
         generate_menu limine/limine.conf.in > "${IMAGE_DIR}/limine.conf"
+        # x1e devicetrees
+        if [ "$APK_ARCH" = "aarch64" ]; then
+            tee -a "${IMAGE_DIR}/limine.conf" >/dev/null <<EOF
+
+/Qualcomm Snapdragon X Series SoC devices
+    comment: Device-trees to use for booting Chimera Linux with kernel ${KERNVER}.
+EOF
+            # TODO: include all dtbloader-supported model dtbs?
+            DTBS=$(find "${ROOT_DIR}/boot/dtbs/dtbs-${KERNVER}"/ -path "*/qcom/x1*.dtb" -not -name "*-el2.dtb")
+            mkdir -p "${LIVE_DIR}/dtbs/qcom"
+            cp $DTBS "${LIVE_DIR}/dtbs/qcom"
+            for DTB in $DTBS; do
+                BOARD="$(chroot "${HOST_DIR}" /usr/bin/dtc -q "/mnt/image/live/dtbs/qcom/${DTB##*/}" | awk -F'"' '/model/ {print $2}')"
+                tee -a "${IMAGE_DIR}/limine.conf" >/dev/null <<EOF
+
+    //${BOARD} (DT)
+    protocol: linux
+    dtb_path: boot():/live/dtbs/qcom/${DTB##*/}
+    kernel_path: boot():/live/${KERNFILE}
+    module_path: boot():/live/initrd
+    cmdline: boot=live live-media=CHIMERA_LIVE init=/usr/bin/init loglevel=4 ${CMDLINE}
+EOF
+            done
+        fi
         # efi executables for usb/disk boot
         mkdir -p "${IMAGE_DIR}/EFI/BOOT"
         case "$APK_ARCH" in


### PR DESCRIPTION
Definitely not the final form of this PR, just something arguably ugly to have here for now which I hacked together earlier this year; once Limine supports EFI drop-in drivers (assuming it happens) https://github.com/TravMurav/dtbloader should be included for `aarch64` in ESP (`IMAGE_DIR`) so no device-specific entries hardcoding one via `dtb_path` or kernel cmdline would be necessary to boot these laptops
<img height="400" src="https://github.com/user-attachments/assets/046fdb58-d4bb-471f-93ab-9f9238bb4f67" />
